### PR TITLE
fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
         run: |
           go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
           go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Verify protoc plugins installation
+        run: |
+          which protoc-gen-go
+          which protoc-gen-go-grpc
+          echo "✓ Plugins installed and accessible"
 
       - name: Generate protobuf code
         run: make proto


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline now generates protobuf sources early and shares them as artifacts across jobs.
  * Jobs updated to download generated proto artifacts before lint, test, build, integration-test, docker, and release steps.
  * Workflow includes new permissions and dependency chaining so codegen runs before downstream steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->